### PR TITLE
Bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ loader_version=0.13.3
 #Fabric api
 fabric_version=0.48.0+1.18.2
 # Mod Properties
-mod_version=1.2
+mod_version=1.2.1
 maven_group=io.github.ladysnake
 archives_base_name=effective
 #Other Dependencies


### PR DESCRIPTION
This is to cause less confusion, to have the build be labeled as v1.2.1 rather than 1.2.